### PR TITLE
Update `--convert` command in under "Additional Options"

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,6 @@ This page will open in your browser:
 
 ## Additional Options
 
-This tool is designed to support workflows with data that changes periodically. When your data changes and you want to update your tileset (hence "data sync"), you can use the `--convert file.geojsonl` option. Assuming you modified your file in place, or overwrote it with new data, use this option to convert the GeoJSON to the line-delimited format. Once that's ready, you can use the `--sync` option to republish the data with the same recipe and settings.
+This tool is designed to support workflows with data that changes periodically. When your data changes and you want to update your tileset (hence "data sync"), you can use the `--convert file.geojson` option. Assuming you modified your file in place, or overwrote it with new data, use this option to convert the GeoJSON to the line-delimited format. Once that's ready, you can use the `--sync` option to republish the data with the same recipe and settings.
 
 If you need to change your secret access token, use the `--token` option to enter a new token.

--- a/src/cli.js
+++ b/src/cli.js
@@ -58,7 +58,7 @@ export async function cli(args) {
     } else if (options.token) {
       setToken();
     } else {
-      console.log(`Run mtsds with valid options: ${eol}--config filename.geojsonl, ${eol}--convert filename.geojsonl, ${eol}--sync, ${eol}--token, ${eol}or --estimate`);
+      console.log(`Run mtsds with valid options: ${eol}--config filename.geojson, ${eol}--convert filename.geojson, ${eol}--sync, ${eol}--token, ${eol}or --estimate`);
     }
   }
 }


### PR DESCRIPTION
### Describe the problem

The existing `--convert` command instructions under [Additional Options](https://github.com/mapbox/mts-data-sync#additional-options) in the README makes it sound like you are meant to include the line-delimited geojson (`geojsonl`) filename as part of the command. 

Instead, you are supposed to include the original source `geojson` file. This is correct in the [Usage](https://github.com/mapbox/mts-data-sync#usage) section but is incorrect under `Additional Options`.