### PR TITLE
Add ability to skip opening a website

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,8 @@ This page will open in your browser:
 
 ![Tileset preview page](./assets/tileset-preview.png)
 
+If you would like to skip opening a website (for example, if this is running as part of a cron job), you can pass in the flag `--skip-opening-web`.
+
 ## Additional Options
 
 This tool is designed to support workflows with data that changes periodically. When your data changes and you want to update your tileset (hence "data sync"), you can use the `--convert file.geojson` option. Assuming you modified your file in place, or overwrote it with new data, use this option to convert the GeoJSON to the line-delimited format. Once that's ready, you can use the `--sync` option to republish the data with the same recipe and settings.

--- a/src/cli.js
+++ b/src/cli.js
@@ -16,6 +16,7 @@ function argsToOptions(rawArgs) {
       "--estimate": Boolean,
       "--convert": String,
       "--token": Boolean,
+      "--skip-opening-web": Boolean,
       "-c": "--config",
       "-s": "--sync",
       "-e": "--estimate"
@@ -30,7 +31,8 @@ function argsToOptions(rawArgs) {
     sync: args["--sync"] || false,
     estimate: args["--estimate"] || false,
     convert: args["--convert"] || false,
-    token: args["--token"] || false
+    token: args["--token"] || false,
+    skipOpeningWeb: args["--skip-opening-web"] || false
   };
 }
 

--- a/src/services.js
+++ b/src/services.js
@@ -136,7 +136,7 @@ const jobStatus = async function (tilesetId, jobId) {
 
 // request the status every 10s, logging the status to the console until it's 'success'
 // provide some kind of preview / visual inspector
-const checkStatus = async function (tilesetId) {
+const checkStatus = async function (tilesetId, options) {
   try {
     const response = await mtsService.tilesetStatus({
       tilesetId: `${process.env.MTS_USERNAME}.${tilesetId}`
@@ -148,7 +148,9 @@ const checkStatus = async function (tilesetId) {
     } else if (response.body.status === "success") {
       console.log(await jobStatus(tilesetId, response.body.latest_job));
       console.log(`Complete: opening https://studio.mapbox.com/tilesets/${response.body.id}/`);
-      open(`https://studio.mapbox.com/tilesets/${response.body.id}/`, { url: true });
+      if(!options.skipOpeningWeb) {
+        open(`https://studio.mapbox.com/tilesets/${response.body.id}/`, { url: true });
+      }
     } else {
       console.log("Error creating tileset", response.body);
       console.log(await jobStatus(tilesetId, response.body.latest_job));

--- a/src/sync.js
+++ b/src/sync.js
@@ -32,19 +32,19 @@ async function runServices(cnf, recipe) {
     await sleep(1500);
     await publishTileset(cnf.tilesetId);
     await sleep(1500);
-    await checkStatus(cnf.tilesetId);
+    await checkStatus(cnf.tilesetId, options);
   } catch (err) {
     console.log(err);
   }
 }
 
-export default function sync() {
+export default function sync(options) {
   const pwd = process.cwd();
 
   const cnf = readConfig(pwd);
   const recipe = readRecipe(pwd);
 
   if (cnf && recipe) {
-    runServices(cnf, recipe);
+    runServices(cnf, recipe, options);
   }
 }


### PR DESCRIPTION
Hi Mapbox!

I love this tool! It has made it so easy for me to work with your tile service. However, I have run into one issue, which I resolve in this pull request. 

I have a use case where I would like to refresh my maps on a regular cadence. (You can think of this like a cron job.) I am able to script everything on my end (generating geojson, converting them to line delineated, etc.) However, on the final step where I call `--sync`, I am getting an error when my script attempts to open a browser. 

This change adds a new flag `--skip-opening-web` which silences that last step. 

