### PR TITLE
Convert Mapbox username to lowercase

### DIFF
--- a/src/token.js
+++ b/src/token.js
@@ -21,7 +21,7 @@ async function promptForToken() {
   const answers = await inquirer.prompt(questions);
 
   return {
-    username: answers.username || "error",
+    username: answers.username.toLowerCase() || "error",
     token: answers.sk || "error"
   };
 }


### PR DESCRIPTION
Mapbox username is always lowercase, so convert `--token` username to lowercase to avoid error 404.
Fix #20 